### PR TITLE
Update default linter rules to allow `this: void` parameter annotatio…

### DIFF
--- a/packages/linter-config/index.ts
+++ b/packages/linter-config/index.ts
@@ -54,6 +54,8 @@ export const baseConfig: ConfigArray = tseslint.config(
         },
       ],
       // Used to allow `this: void` in methods, so that @typescript-eslint/unbound-method can be silenced properly
+      // note that often, it should be preferable to disable the unbound-method rule instead
+      // see https://bsky.app/profile/janis.me/post/3lrgjseighs2s
       '@typescript-eslint/no-invalid-void-type': [
         'error',
         {


### PR DESCRIPTION
…ns for methods

This is done to allow silencing the `no unbound method` rule. That rule makes a lot of sense, but should be easily to silence.